### PR TITLE
bugfix: hierarchical containers with more than two levels (fixes #39)

### DIFF
--- a/src/main/java/com/vaadin/addon/tableexport/ExcelExport.java
+++ b/src/main/java/com/vaadin/addon/tableexport/ExcelExport.java
@@ -516,10 +516,6 @@ public class ExcelExport extends TableExport {
             if (displayTotals) {
                 addDataRow(hierarchicalTotalsSheet, rootId, localRow);
             }
-            if (count > 1) {
-                sheet.groupRow(localRow + 1, (localRow + count) - 1);
-                sheet.setRowGroupCollapsed(localRow + 1, true);
-            }
             localRow = localRow + count;
         }
         return localRow;
@@ -557,17 +553,14 @@ public class ExcelExport extends TableExport {
      * @return the int
      */
     private int addDataRowRecursively(final Sheet sheetToAddTo, final Object rootItemId, final int row) {
-        int numberAdded = 0;
-        int localRow = row;
         addDataRow(sheetToAddTo, rootItemId, row);
-        numberAdded++;
-        if (((Container.Hierarchical) getTableHolder().getContainerDataSource()).hasChildren(rootItemId)) {
-            final Collection<?> children = ((Container.Hierarchical) getTableHolder().getContainerDataSource())
-                    .getChildren(rootItemId);
+        int numberAdded = 1;
+        final Collection<?> children = ((Container.Hierarchical) getTableHolder().getContainerDataSource()).getChildren(rootItemId);
+        if (children != null) {
             for (final Object child : children) {
-                localRow++;
-                numberAdded = numberAdded + addDataRowRecursively(sheetToAddTo, child, localRow);
+                numberAdded += addDataRowRecursively(sheetToAddTo, child, row + numberAdded);
             }
+            sheet.groupRow(row + 1, row + numberAdded - 1);
         }
         return numberAdded;
     }


### PR DESCRIPTION
Hi,
please have a look at my bugfix für issue #39.

(I also removed the explicit collapsing of groups, so that all levels/rows will be visible, when the user opens the excel file)

Stefan