### PR TITLE
Fixed an issue where the valueType is Date whilst the value is of a different type...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.vaadin.addon</groupId>
     <artifactId>tableexport-for-vaadin-root</artifactId>
     <packaging>pom</packaging>
-    <version>1.8.0</version>
+    <version>1.8.0.1</version>
     <name>TableExport Add-on Root</name>
 
 	<modules>

--- a/tableexport-demo/pom.xml
+++ b/tableexport-demo/pom.xml
@@ -10,7 +10,7 @@
     <groupId>com.vaadin.addon</groupId>
     <artifactId>tableexport-for-vaadin-demo</artifactId>
     <packaging>war</packaging>
-    <version>1.8.0</version>
+    <version>1.8.0.1</version>
     <name>TableExport-Demo</name>
 
     <organization>
@@ -19,7 +19,7 @@
     </organization>
 
     <properties>
-        <tableexport.version>1.8.0</tableexport.version>
+        <tableexport.version>1.8.0.1</tableexport.version>
         <vaadin.version>8.2.1</vaadin.version>
         <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
         <jetty.plugin.version>9.2.3.v20140905</jetty.plugin.version>

--- a/tableexport/pom.xml
+++ b/tableexport/pom.xml
@@ -11,7 +11,7 @@
     <groupId>com.vaadin.addon</groupId>
     <artifactId>tableexport-for-vaadin</artifactId>
     <packaging>jar</packaging>
-    <version>1.8.0</version>
+    <version>1.8.0.1</version>
     <name>TableExport</name>
 
     <organization>

--- a/tableexport/src/main/java/com/vaadin/addon/tableexport/ExcelExport.java
+++ b/tableexport/src/main/java/com/vaadin/addon/tableexport/ExcelExport.java
@@ -585,7 +585,7 @@ public class ExcelExport extends TableExport {
 	protected void setCellValue(Cell sheetCell, Object value, Class<?> valueType, Object propId) {
 		if (null != value) {
 		    if (!isNumeric(valueType)) {
-		        if (java.util.Date.class.isAssignableFrom(valueType)) {
+		        if (java.util.Date.class.isAssignableFrom(value.getClass())) {
 		            sheetCell.setCellValue((Date) value);
 		        } else {
 		            sheetCell.setCellValue(createHelper.createRichTextString(value.toString()));


### PR DESCRIPTION
Fixed an issue where the valueType is Date (In ExcelExport.java line 588) whilst the value is of a different type due to setUseTableFormatPropertyValue(true) which can convert a date to a String value representation instead. This leads to a class cast exception in ExcelExport.java line 589 when a String is being cast to a Date type.